### PR TITLE
Add default Ergast API URL to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,3 +62,4 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+ERGAST_API_URL=https://ergast.com/api/f1/current.json


### PR DESCRIPTION
## Summary
- add ERGAST API URL to `.env.example` so new setups have default endpoint

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --no-interaction` *(fails: nette/schema requires php 8.1 - 8.3, current 8.4.11)*

------
https://chatgpt.com/codex/tasks/task_e_68adcdd63b60832ea373c8ac1d717274